### PR TITLE
Add collectables as yellow square on map

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -148,6 +148,10 @@ td.danger {
     background: #e21;
 }
 
+td.collectable {
+    background: #db2;
+}
+
 td.void {
     background: #111;
 }

--- a/app/js/modules/MiniMap.js
+++ b/app/js/modules/MiniMap.js
@@ -4,6 +4,8 @@
 
 import game from '../game.js';
 import Monster from "./things/Monster.js";
+import Food from "./things/Food.js";
+import Weapon from "./things/Weapon.js";
 
 /**
  * A minimap in the corner of the game.
@@ -33,6 +35,7 @@ export default class MiniMap {
         $('td')
             .removeClass('danger')
             .removeClass('explored')
+            .removeClass('collectable')
             .removeClass('origin')
             .removeClass('player')
             .removeClass('void');
@@ -50,6 +53,8 @@ export default class MiniMap {
                         box.addClass('void');
                     } else if (room.contents.filter(thing => thing instanceof Monster).length > 0) {
                         box.addClass('danger');
+                    } else if (room.contents.filter(thing => thing instanceof Food || thing instanceof Weapon).length > 0) {
+                        box.addClass('collectable');
                     } else {
                         box.addClass('explored');
                     }


### PR DESCRIPTION
Adds Food and Weapons in rooms without monsters as a yellow square on the minimap.

![Screenshot 2021-01-28 162359](https://user-images.githubusercontent.com/31376393/106200624-3dc81700-6185-11eb-8572-bc85b3e9df5d.png)
